### PR TITLE
removed shadowing of armoritems/handitems as well as overriding methods for correct implementation and a weird crash

### DIFF
--- a/src/main/java/com/notenoughmail/kubejs_tfc/addons/entityjs/entities/DairyAnimalJS.java
+++ b/src/main/java/com/notenoughmail/kubejs_tfc/addons/entityjs/entities/DairyAnimalJS.java
@@ -74,8 +74,6 @@ public class DairyAnimalJS extends DairyAnimal implements IAnimatableJS {
 
     protected PathNavigation navigation;
     public final PartEntityJS<?>[] partEntities;
-    private final NonNullList<ItemStack> handItems = NonNullList.withSize(2, ItemStack.EMPTY);
-    private final NonNullList<ItemStack> armorItems = NonNullList.withSize(4, ItemStack.EMPTY);
 
     public DairyAnimalJS(EntityType<? extends DairyAnimal> animal, Level level, DairyAnimalJSBuilder builder) {
         super(animal, level, builder.sounds, builder.config.producingMammal());
@@ -1619,30 +1617,4 @@ public class DairyAnimalJS extends DairyAnimal implements IAnimatableJS {
     }
 
 
-    @Override
-    public Iterable<ItemStack> getArmorSlots() {
-        return armorItems;
-    }
-
-    @Override
-    public Iterable<ItemStack> getHandSlots() {
-        return handItems;
-    }
-
-    @Override
-    public ItemStack getItemBySlot(EquipmentSlot slot) {
-        return switch (slot.getType()) {
-            case HAND -> handItems.get(slot.getIndex());
-            case ARMOR -> armorItems.get(slot.getIndex());
-        };
-    }
-
-    @Override
-    public void setItemSlot(EquipmentSlot slot, ItemStack stack) {
-        verifyEquippedItem(stack);
-        switch (slot.getType()) {
-            case HAND -> onEquipItem(slot, handItems.set(slot.getIndex(), stack), stack);
-            case ARMOR -> onEquipItem(slot, armorItems.set(slot.getIndex(), stack), stack);
-        }
-    }
 }

--- a/src/main/java/com/notenoughmail/kubejs_tfc/addons/entityjs/entities/MammalJS.java
+++ b/src/main/java/com/notenoughmail/kubejs_tfc/addons/entityjs/entities/MammalJS.java
@@ -73,8 +73,6 @@ public class MammalJS extends Mammal implements IAnimatableJS {
 
     protected PathNavigation navigation;
     public final PartEntityJS<?>[] partEntities;
-    private final NonNullList<ItemStack> handItems = NonNullList.withSize(2, ItemStack.EMPTY);
-    private final NonNullList<ItemStack> armorItems = NonNullList.withSize(4, ItemStack.EMPTY);
 
     public MammalJS(EntityType<? extends TFCAnimal> animal, Level level, MammalJSBuilder builder) {
         super(animal, level, builder.sounds, builder.config.mammal());
@@ -1612,31 +1610,4 @@ public class MammalJS extends Mammal implements IAnimatableJS {
         }
     }
 
-
-    @Override
-    public Iterable<ItemStack> getArmorSlots() {
-        return armorItems;
-    }
-
-    @Override
-    public Iterable<ItemStack> getHandSlots() {
-        return handItems;
-    }
-
-    @Override
-    public ItemStack getItemBySlot(EquipmentSlot slot) {
-        return switch (slot.getType()) {
-            case HAND -> handItems.get(slot.getIndex());
-            case ARMOR -> armorItems.get(slot.getIndex());
-        };
-    }
-
-    @Override
-    public void setItemSlot(EquipmentSlot slot, ItemStack stack) {
-        verifyEquippedItem(stack);
-        switch (slot.getType()) {
-            case HAND -> onEquipItem(slot, handItems.set(slot.getIndex(), stack), stack);
-            case ARMOR -> onEquipItem(slot, armorItems.set(slot.getIndex(), stack), stack);
-        }
-    }
 }

--- a/src/main/java/com/notenoughmail/kubejs_tfc/addons/entityjs/entities/OviparousAnimalJS.java
+++ b/src/main/java/com/notenoughmail/kubejs_tfc/addons/entityjs/entities/OviparousAnimalJS.java
@@ -73,8 +73,6 @@ public class OviparousAnimalJS extends OviparousAnimal implements IAnimatableJS 
 
     protected PathNavigation navigation;
     public final PartEntityJS<?>[] partEntities;
-    private final NonNullList<ItemStack> handItems = NonNullList.withSize(2, ItemStack.EMPTY);
-    private final NonNullList<ItemStack> armorItems = NonNullList.withSize(4, ItemStack.EMPTY);
 
     public OviparousAnimalJS(EntityType<? extends OviparousAnimal> type, Level level, OviparousAnimalJSBuilder builder) {
         super(type, level, builder.sounds, builder.config.oviparous(), builder.crows);
@@ -1617,31 +1615,4 @@ public class OviparousAnimalJS extends OviparousAnimal implements IAnimatableJS 
         }
     }
 
-
-    @Override
-    public Iterable<ItemStack> getArmorSlots() {
-        return armorItems;
-    }
-
-    @Override
-    public Iterable<ItemStack> getHandSlots() {
-        return handItems;
-    }
-
-    @Override
-    public ItemStack getItemBySlot(EquipmentSlot slot) {
-        return switch (slot.getType()) {
-            case HAND -> handItems.get(slot.getIndex());
-            case ARMOR -> armorItems.get(slot.getIndex());
-        };
-    }
-
-    @Override
-    public void setItemSlot(EquipmentSlot slot, ItemStack stack) {
-        verifyEquippedItem(stack);
-        switch (slot.getType()) {
-            case HAND -> onEquipItem(slot, handItems.set(slot.getIndex(), stack), stack);
-            case ARMOR -> onEquipItem(slot, armorItems.set(slot.getIndex(), stack), stack);
-        }
-    }
 }

--- a/src/main/java/com/notenoughmail/kubejs_tfc/addons/entityjs/entities/WoolyAnimalJS.java
+++ b/src/main/java/com/notenoughmail/kubejs_tfc/addons/entityjs/entities/WoolyAnimalJS.java
@@ -74,8 +74,6 @@ public class WoolyAnimalJS extends WoolyAnimal implements IAnimatableJS {
 
     protected PathNavigation navigation;
     public final PartEntityJS<?>[] partEntities;
-    private final NonNullList<ItemStack> handItems = NonNullList.withSize(2, ItemStack.EMPTY);
-    private final NonNullList<ItemStack> armorItems = NonNullList.withSize(4, ItemStack.EMPTY);
 
     public WoolyAnimalJS(EntityType<? extends WoolyAnimal> animal, Level level, WoolAnimalJSBuilder builder) {
         super(animal, level, builder.sounds, builder.config.producingMammal());
@@ -1619,30 +1617,4 @@ public class WoolyAnimalJS extends WoolyAnimal implements IAnimatableJS {
     }
 
 
-    @Override
-    public Iterable<ItemStack> getArmorSlots() {
-        return armorItems;
-    }
-
-    @Override
-    public Iterable<ItemStack> getHandSlots() {
-        return handItems;
-    }
-
-    @Override
-    public ItemStack getItemBySlot(EquipmentSlot slot) {
-        return switch (slot.getType()) {
-            case HAND -> handItems.get(slot.getIndex());
-            case ARMOR -> armorItems.get(slot.getIndex());
-        };
-    }
-
-    @Override
-    public void setItemSlot(EquipmentSlot slot, ItemStack stack) {
-        verifyEquippedItem(stack);
-        switch (slot.getType()) {
-            case HAND -> onEquipItem(slot, handItems.set(slot.getIndex(), stack), stack);
-            case ARMOR -> onEquipItem(slot, armorItems.set(slot.getIndex(), stack), stack);
-        }
-    }
 }


### PR DESCRIPTION
These methods are only required when extending the base LivingEntity class where implementation is required, shadowing/implementing farther down the chain is unnecessary and will lead to inconsistencies and in some cases a crash 