### PR TITLE
Fix NoSuchMethodError in TFCLeavesBlockBuilder with TFC 4.2.4+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,14 +20,14 @@ mod_group_id=io.github.notenoughmail.kubejstfc
 mod_authors=NotEnoughMail
 mod_description=KubeJS compatibility for TFC
 
-tfc_version_range=[4.2.0,)
+tfc_version_range=[4.2.4,)
 kube_version_range=[2101.7.2-build.343,)
 # firmalife_version_range=[2.1.12,)
 
 # Dependencies
 #     TFC
 # https://www.curseforge.com/minecraft/mc-mods/terrafirmacraft/files
-tfc_file=8296252
+tfc_file=8365958
 cyanide_file=5782674
 patchi_file=6842247
 jade_file=6853386

--- a/src/main/java/io/github/notenoughmail/kubejstfc/blocks/TFCLeavesBlockBuilder.java
+++ b/src/main/java/io/github/notenoughmail/kubejstfc/blocks/TFCLeavesBlockBuilder.java
@@ -14,9 +14,15 @@ import io.github.notenoughmail.kubejstfc.util.Assistant;
 import io.github.notenoughmail.kubejstfc.util.DelayedBuilder;
 import io.github.notenoughmail.kubejstfc.util.ModelUtil;
 import net.dries007.tfc.common.blocks.wood.TFCLeavesBlock;
+import net.dries007.tfc.common.blocks.wood.Wood;
+import net.dries007.tfc.util.registry.RegistryWood;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.grower.TreeGrower;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
+import net.minecraft.world.level.block.state.properties.WoodType;
+import net.minecraft.world.level.material.MapColor;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
@@ -62,7 +68,72 @@ public class TFCLeavesBlockBuilder extends LeavesBuilder {
 
     @Override
     public Block createObject() {
-        return new TFCLeavesBlock(createExtendedProperties().randomTicks().noOcclusion(), autumnIndex, fallenLeaves.get(), twig);
+        return new TFCLeavesBlock(createExtendedProperties().randomTicks().noOcclusion(), wood(), fallenLeaves.get(), twig);
+    }
+
+    /**
+     * TFC 4.2.4 changed the {@link TFCLeavesBlock} constructor to take a {@link RegistryWood}
+     * instead of a raw autumn index. The block only ever queries {@code autumnIndex()},
+     * {@code isConifer()} and {@code getFlowerOffset()} from it, so a minimal wrapper around
+     * the builder's autumn index is provided; the remaining methods are never called by the block
+     */
+    private RegistryWood wood() {
+        return new RegistryWood() {
+            @Override
+            public String getSerializedName() {
+                return id.getPath();
+            }
+
+            @Override
+            public int autumnIndex() {
+                return autumnIndex;
+            }
+
+            @Override
+            public boolean isConifer() {
+                return false;
+            }
+
+            @Override
+            public float getFlowerOffset() {
+                return 0F;
+            }
+
+            @Override
+            public MapColor woodColor() {
+                return MapColor.WOOD;
+            }
+
+            @Override
+            public MapColor barkColor() {
+                return MapColor.PODZOL;
+            }
+
+            @Override
+            public TreeGrower tree() {
+                throw new UnsupportedOperationException("KubeJS-TFC's leaves do not have an associated tree grower");
+            }
+
+            @Override
+            public Supplier<Integer> ticksToGrow() {
+                throw new UnsupportedOperationException("KubeJS-TFC's leaves do not have an associated sapling");
+            }
+
+            @Override
+            public Supplier<Block> getBlock(Wood.BlockType type) {
+                throw new UnsupportedOperationException("KubeJS-TFC's leaves do not have associated wood blocks");
+            }
+
+            @Override
+            public BlockSetType getBlockSet() {
+                throw new UnsupportedOperationException("KubeJS-TFC's leaves do not have an associated block set");
+            }
+
+            @Override
+            public WoodType getVanillaWoodType() {
+                throw new UnsupportedOperationException("KubeJS-TFC's leaves do not have an associated wood type");
+            }
+        };
     }
 
     @Override


### PR DESCRIPTION
## Problem

Registering leaves via the leaves builder with KubeJS-TFC 2.0.1 against TFC 4.2.5 (`TerraFirmaCraft-NeoForge-1.21.1-4.2.5`) crashes with:

```
java.lang.NoSuchMethodError: 'void net.dries007.tfc.common.blocks.wood.TFCLeavesBlock.<init>(net.dries007.tfc.common.blocks.ExtendedProperties, int, java.util.function.Supplier, java.util.function.Supplier)'
	at io.github.notenoughmail.kubejstfc.blocks.TFCLeavesBlockBuilder.createObject
```

TFC 4.2.4 changed the `TFCLeavesBlock` constructor signature from

```java
TFCLeavesBlock(ExtendedProperties properties, int autumnIndex, @Nullable Supplier<? extends Block> fallenLeaves, @Nullable Supplier<? extends Block> fallenTwig)
```

to

```java
TFCLeavesBlock(ExtendedProperties properties, RegistryWood wood, @Nullable Supplier<? extends Block> fallenLeaves, @Nullable Supplier<? extends Block> fallenTwig)
```

(`RegistryWood` also gained `isConifer()` and `getFlowerOffset()` in that release.)

## Fix

- `TFCLeavesBlockBuilder#createObject` now passes a minimal anonymous `RegistryWood` that wraps the builder's `autumnIndex` and returns neutral defaults for `isConifer()` (`false`) and `getFlowerOffset()` (`0`). `TFCLeavesBlock` only ever queries these three methods from the wood, so the remaining methods throw `UnsupportedOperationException`.
- `gradle.properties`: compile against TFC 4.2.5 (file `8365958`) and bump `tfc_version_range` to `[4.2.4,)`, since the compiled constructor call no longer links against 4.2.0-4.2.3.

## Reproduction

With KubeJS-TFC 2.0.1 + TFC 4.2.5 on NeoForge 1.21.1 (21.1.235), any startup script that does `event.create(id, tfc:leaves)` (e.g. porting TerraFirmaGreg-Modern custom trees) throws the above error during block registration.

The branch compiles cleanly against TFC 4.2.5 / KubeJS 2101.7.2-build.368 (`./gradlew build`); an in-game runtime test of the patched jar is still pending on my side.

If you would rather expose `isConifer`/`flowerOffset` to scripts as new builder options instead of hardcoding defaults, happy to extend the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)