### PR TITLE
fix: resolve logic flaws in tree solving, block models, particle ticks, and worldgen validation

### DIFF
--- a/src/main/java/io/github/notenoughmail/kubejstfc/blocks/ThinSpikeBlockBuilder.java
+++ b/src/main/java/io/github/notenoughmail/kubejstfc/blocks/ThinSpikeBlockBuilder.java
@@ -95,9 +95,7 @@ public class ThinSpikeBlockBuilder extends BlockBuilder {
                             Climate.getInstantTemperature(level, pos) > dripTemp &&
                             random.nextFloat() < dripChance
                     ) {
-                        if (random.nextFloat() < dripChance) {
-                            spawnParticle(level, pos, state, particle.get());
-                        }
+                        spawnParticle(level, pos, state, particle.get());
                     }
                 }
             }

--- a/src/main/java/io/github/notenoughmail/kubejstfc/blocks/sub/FallenLeavesBlockBuilder.java
+++ b/src/main/java/io/github/notenoughmail/kubejstfc/blocks/sub/FallenLeavesBlockBuilder.java
@@ -104,7 +104,7 @@ public class FallenLeavesBlockBuilder extends LeavesBuilder {
         FallenLeavesModelType() {
             layers = ordinal() + 1;
             str = Integer.toString(layers * 2);
-            parentModel = layers == 8 ? KubeJSTFC.tfc("block/groundcover/fallen_leaves_height" + str) : LeavesBuilder.LEAVES;
+            parentModel = layers == 8 ? LeavesBuilder.LEAVES : KubeJSTFC.tfc("block/groundcover/fallen_leaves_height" + str);
         }
 
         @Override

--- a/src/main/java/io/github/notenoughmail/kubejstfc/compat/worldjs/builders/forest/KrummholzBuilder.java
+++ b/src/main/java/io/github/notenoughmail/kubejstfc/compat/worldjs/builders/forest/KrummholzBuilder.java
@@ -31,7 +31,7 @@ public class KrummholzBuilder extends ConfiguredFeatureBuilder.WithFeature<Krumm
     @Info("The krummholz block to place")
     public KrummholzBuilder krummholz(Block k) {
         final Collection<Property<?>> props = k.getStateDefinition().getProperties();
-        if (!(props.contains(KrummholzBlock.TIP) || props.contains(KrummholzBlock.BOTTOM))) {
+        if (!(props.contains(KrummholzBlock.TIP) && props.contains(KrummholzBlock.BOTTOM))) {
             throw exception("Krummholz block must have tip and bottom block properties!")
                     .customData("tip property", KrummholzBlock.TIP)
                     .customData("bottom property", KrummholzBlock.BOTTOM)

--- a/src/main/java/io/github/notenoughmail/kubejstfc/util/commands/TreeSolver.java
+++ b/src/main/java/io/github/notenoughmail/kubejstfc/util/commands/TreeSolver.java
@@ -350,7 +350,7 @@ public class TreeSolver {
             for (Direction dir1 : Helpers.DIRECTIONS) {
                 if (dir1.getAxis() != dir0.getAxis() && nextPositions.contains(nextPos.offset(
                         dir0.getStepX() + dir1.getStepX(),
-                        dir0.getStepY() + dir1.getStepZ(),
+                        dir0.getStepY() + dir1.getStepY(),
                         dir0.getStepZ() + dir1.getStepZ()
                 ))) {
                     return true;

--- a/src/main/resources/assets/kubejs_tfc/models/block/groundcover/loose/igneous_intrusive_3.json
+++ b/src/main/resources/assets/kubejs_tfc/models/block/groundcover/loose/igneous_intrusive_3.json
@@ -1,5 +1,5 @@
 {
-  "parent": "tfc:block/rock/loose_igneous_intrusive_2",
+  "parent": "tfc:block/rock/loose_igneous_intrusive_3",
   "textures": {
     "texture": "#all"
   }

--- a/src/main/resources/assets/kubejs_tfc/models/block/groundcover/loose/metamorphic_3.json
+++ b/src/main/resources/assets/kubejs_tfc/models/block/groundcover/loose/metamorphic_3.json
@@ -1,5 +1,5 @@
 {
-  "parent": "tfc:block/rock/loose_metamorphic_1",
+  "parent": "tfc:block/rock/loose_metamorphic_3",
   "textures": {
     "texture": "#all"
   }


### PR DESCRIPTION
This pull request addresses several logic errors and asset discrepancies across block generation, particle ticking, tree solving, and worldgen property validation.

### Proposed Changes:

**Bug Fixes:**
* Fixed neighbor Y-axis calculation in `TreeSolver#containsCorner` where `dir1.getStepZ()` was used instead of `dir1.getStepY()`.
* Corrected inverted ternary logic in `FallenLeavesModelType` constructor so partial fallen leaves layers (1–7) use their height-specific groundcover models rather than full-block leaf models.
* Removed redundant nested `random.nextFloat() < dripChance` check in `ThinSpikeBlockBuilder#animateTick` to prevent unintended probability squaring.
* Updated property validation in `KrummholzBuilder#krummholz` to enforce that configured blocks contain both `TIP` and `BOTTOM` properties before worldgen placement.
* Corrected parent model references in `igneous_intrusive_3.json` and `metamorphic_3.json` to point to their respective 3-pebble parent models.